### PR TITLE
update eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chai-as-promised": "5.1.0",
     "chalk": "1.1.1",
     "connect-mustache-middleware": "git+https://github.com/DigitalInnovation/connect-mustache-middleware",
-    "eslint": "1.2.1",
+    "eslint": "1.10.3",
     "eslint-config-fear-core": "git+https://github.com/digitalinnovation/fear-core-eslint-config",
     "fs-extra": "0.24.0",
     "gulp-batch": "1.0.5",


### PR DESCRIPTION
Fix linting bug b&c is facing where the following constructs in the tasks folder get wrongfully flagged:
```js
var config = core.utils.config();
```

According to eslint changelog this error got fixed in 1.7.0. But current pr upgrades eslint to latest version.